### PR TITLE
handle path fragments containing '+' characters

### DIFF
--- a/dispatch.php
+++ b/dispatch.php
@@ -469,7 +469,7 @@ function dispatch() {
 
       # extract any route symbol values
       $toks = array_filter(array_keys($vals), 'is_string');
-      $vals = array_map('urldecode', array_intersect_key(
+      $vals = array_map('rawurldecode', array_intersect_key(
         $vals,
         array_flip($toks)
       ));


### PR DESCRIPTION
Previous behavior was to decode the path fragments with urldecode() but this will treats '+' character as space character which is not correct for the path fragment of a url (this is only valid for the query fragment of a url). Using rawurldecode will correctly decode the path.